### PR TITLE
[Step 5] adds material attributes to consistently style the title, subtitle and header

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,14 +10,20 @@
                 android:layout_height="match_parent"
                 android:orientation="vertical">
 
+<!--        we want to change the toolbar and any associated children to have a dark theme-->
+<!--        we need to specify the color in the background attribute-->
+<!--        set the image tint to cause the image view to be tinted to a specified color-->
             <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
+                    android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                    android:background="?colorPrimaryDark"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize">
                 <ImageView
                         android:id="@+id/hero_image"
                         android:layout_width="150dp"
                         android:layout_height="match_parent"
+                    android:tint="?colorOnPrimary"
                         app:srcCompat="@drawable/logo"
                         android:contentDescription="@string/app_name"/>
             </androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/home_fragment.xml
+++ b/app/src/main/res/layout/home_fragment.xml
@@ -40,17 +40,20 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintDimensionRatio="4:3"/>
 
+<!--            we use the proper syntax to look up and apply the value of headline5-->
+<!--            using textAppearance attribute prevents style from overriding the theme-->
+<!--            textAppearance is an attribute on any view that applies text-->
                 <TextView
                     android:id="@+id/title"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:fontFamily="monospace"
+                    android:textAppearance="?textAppearanceHeadline5"
                     android:text="@string/about_google_developer_groups"
-                    style="@style/TextAppearance.Title"
                     app:layout_constraintEnd_toStartOf="@+id/end_grid"
                     app:layout_constraintStart_toStartOf="@+id/start_grid"
-                    app:layout_constraintTop_toBottomOf="@id/image" />
+                    app:layout_constraintTop_toBottomOf="@id/image"
+                    android:fontFamily="@font/lobster_two" />
 
                 <TextView
                     android:id="@+id/intro_text"
@@ -66,12 +69,9 @@
                     android:id="@+id/subtitle"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="13dp"
-                    android:fontFamily="sans-serif"
                     android:text="@string/gdgs_are"
-                    style="@style/TextAppearance.Subtitle"
-                    android:textColor="#555555"
-                    android:textSize="18sp"
+                    android:layout_marginTop="13dp"
+                    android:textAppearance="?textAppearanceHeadline6"
                     app:layout_constraintEnd_toStartOf="@id/end_grid"
                     app:layout_constraintStart_toEndOf="@id/start_grid"
                     app:layout_constraintTop_toBottomOf="@+id/intro_text" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,19 +8,12 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="fontFamily">@font/lobster_two</item>
         <item name="android:fontFamily">@font/lobster_two</item>
+<!--    this theme attribute will override whatever style the theme specified in textAppearanceHeadline6 -->
+        <item name="textAppearanceHeadline6">@style/CustomHeadline6</item>
     </style>
 
-<!-- add style for title-->
-<!-- style has a name and a parent-->
-<!-- here we use the default style for the material component as the parent-->
-    <style name="TextAppearance.Title" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="android:textSize">24sp</item>
-        <item name="android:textColor">#555555</item>
-    </style>
-
-<!-- add style for subtitle-->
-<!-- we use the title style as our parent-->
-    <style name="TextAppearance.Subtitle" parent="TextAppearance.Title">
+<!-- extend the default style here so we can just change the attributes necessary-->
+    <style name="CustomHeadline6" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textSize">18sp</item>
     </style>
 


### PR DESCRIPTION
- add a text apperance attribute to title and subtitle and set it to the material theme's default style
- replace textAppearanceHeadline6 with a custom attribute to change the text size
- apply a material dark them to the toolbar to add contrast to the app